### PR TITLE
Enable custom specification of logfile parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ imapfilter_update() {
         kill -TERM "$imapfilter_pid"
         wait "$imapfilter_pid"
     fi
-    imapfilter -c "$config_target" &
+    imapfilter -c "$config_target" -l "$IMAPFILTER_LOGFILE" &
     imapfilter_pid="$(jobs -p)"
 }
 
@@ -74,7 +74,7 @@ while true; do
         fi
     else
         printf ">>> Running imapfilter\n"
-        imapfilter -c "$config_target"
+        imapfilter -c "$config_target" -l "$IMAPFILTER_LOGFILE"
     fi
 
     printf ">>> Sleeping\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,6 +11,11 @@ else
     config_target="$IMAPFILTER_CONFIG"
 fi
 
+log_parameter=
+if [ -n "$IMAPFILTER_LOGFILE" ]; then
+	log_parameter="-l '$IMAPFILTER_LOGFILE'"
+fi
+
 updated_config=no
 pull_config() {
     updated_config=no
@@ -51,7 +56,7 @@ imapfilter_update() {
         kill -TERM "$imapfilter_pid"
         wait "$imapfilter_pid"
     fi
-    imapfilter -c "$config_target" -l "$IMAPFILTER_LOGFILE" &
+    imapfilter -c "$config_target" $log_parameter &
     imapfilter_pid="$(jobs -p)"
 }
 
@@ -74,7 +79,7 @@ while true; do
         fi
     else
         printf ">>> Running imapfilter\n"
-        imapfilter -c "$config_target" -l "$IMAPFILTER_LOGFILE"
+        imapfilter -c "$config_target" $log_parameter
     fi
 
     printf ">>> Sleeping\n"


### PR DESCRIPTION
Hey.
thanks for the nice docker image! 
I figured that I'd want access to the log files to as I've had when it didn't run in docker so I've added a custom environment variable for it. 

I didn't integrate it with your config base approach, since logs are usually stored elsewhere and hence could just be directed to some mounted volume.