### PR TITLE
Move pushing to docker hub back into steps

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -81,21 +81,15 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-
-  push-to-docker-hub:
-    needs: build
-    runs-on: ubuntu-latest
-    if: ${{ github.repository == 'ntnn/docker-imapfilter' && github.ref == 'refs/heads/main' }}
-
-    steps:
       - uses: docker/login-action@v3
+        if: ${{ github.repository == 'ntnn/docker-imapfilter' && github.ref == 'refs/heads/main' }}
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
-      - run: |
-          for tag in ${{ needs.build.outputs.tags }}; do
+
+      - if: ${{ github.repository == 'ntnn/docker-imapfilter' && github.ref == 'refs/heads/main' }}
+        run: |
+          echo "${{ steps.meta.outputs.tags }}" | while read tag; do
             version="${tag##*:}"
             docker tag "$tag" "ntnn/imapfilter:$version"
             docker push "ntnn/imapfilter:$version"


### PR DESCRIPTION
On matrix'ed jobs the outputs are overwritten, so the slowest job wins. There are some other workarounds like using a variables in the job output name and matrixing the depending job or creating job artifacts that are then downloaded by the depending job - but they are not pretty.