### PR TITLE
PUID and PGID Environment Variable Support and some changes changes to VCS functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,19 +16,21 @@ RUN apk --no-cache add lua openssl pcre git \
 
 FROM alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1
 
-# create an empty config.lua to prevent an error when running imapfilter directly
-RUN adduser -D -u 1001 imapfilter \
-    && mkdir -p /home/imapfilter/.imapfilter && touch /home/imapfilter/.imapfilter/config.lua \
+# Install runtime dependencies for imapfilter and the required tools for user management (shadow for 'su').
+RUN apk --no-cache add lua lua-dev openssl pcre git shadow \
     && mkdir -p /opt/imapfilter/config \
-    && chown imapfilter: /opt/imapfilter
+    && mkdir -p /home/imapfilter/.imapfilter && touch /home/imapfilter/.imapfilter/config.lua 
 
 COPY --from=builder /usr/local/bin/imapfilter /usr/local/bin/imapfilter
 COPY --from=builder /usr/local/share/imapfilter /usr/local/share/imapfilter
 COPY --from=builder /usr/local/man /usr/local/man
 
-RUN apk --no-cache add lua lua-dev openssl pcre git
+# Copy the application logic script
+COPY --chmod=a+x run-imapfilter.sh /run-imapfilter.sh
+# Copy the entrypoint script
+COPY --chmod=a+x entrypoint.sh /entrypoint.sh
 
-COPY --chown=imapfilter: --chmod=a+x entrypoint.sh /entrypoint.sh
-
-USER imapfilter
+# Set the USER to root so we can execute the user setup and then switch users.
+USER root
+# The primary ENTRYPOINT is the user setup script.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,146 +1,63 @@
 #!/usr/bin/env sh
+set -e
 
-vcs_token() {
-    if [ -n "$GIT_TOKEN_RAW" ]; then
-        echo "$GIT_TOKEN_RAW"
-        return
-    fi
+# --- 1. Set PUID/PGID with defaults ---
+# Default to 1001 if PUID or PGID environment variables aren't set.
+PUID=${PUID:-1001}
+PGID=${PGID:-1001}
+# Username for imapfilter user.
+USER_NAME="imapfilter"
 
-    if [ -n "$GIT_TOKEN" ]; then
-        cat "${GIT_TOKEN}"
-    fi
+printf ">>> Setting up user with PUID/PGID: %s/%s\n" "$PUID" "$PGID"
 
-    return 1
-}
+# --- 2. Create/Recreate Group based on PGID ---
+# check if group exists.
+if getent group "$USER_NAME" >/dev/null; then
+    # Get the current GID of the 'imapfilter' group
+    CURRENT_GID=$(getent group "$USER_NAME" | cut -d: -f3)
 
-vcs_uri() {
-    s="https://"
-    if [ -n "$GIT_USER" ]; then
-        # https://user:
-        s="${s}${GIT_USER}:"
-    fi
-
-    # https://user:token@"
-    token="$(vcs_token)"
-    if [ -n "$token" ]; then
-        s="${s}${token}@"
-    fi
-
-    # https://user:token@target
-    echo "${s}${GIT_TARGET}"
-}
-
-config_in_vcs() {
-    [ -n "$(vcs_token)" ] && [ -n "$GIT_TARGET" ]
-}
-
-config_target_base="${IMAPFILTER_CONFIG_BASE:-/opt/imapfilter/config}"
-config_target="${IMAPFILTER_CONFIG}"
-
-# If config_target is an absolute path strip the base.
-# Originally IMAPFILTER_CONFIG was allowed to be absolute and relative,
-# this handles the former absolute path (as long as
-# IMAPFILTER_CONFIG_BASE is correctly used).
-case "$config_target" in
-    (/*) config_target="${config_target#${config_target_base}/}";;
-esac
-
-pull_config() {
-    config_in_vcs || return
-
-    printf ">>> Updating config\n"
-    if [ ! -d "$config_target_base" ]; then
-        printf ">>> Config has not been cloned yet, cloning\n"
-        mkdir -p "$config_target_base"
-        git clone "$(vcs_uri)" "$config_target_base"
-        return
+    if [ "$CURRENT_GID" != "$PGID" ]; then
+        # Group exists but with the wrong GID, so we delete and re-create it
+        printf "Group '%s' exists (GID %s) but doesn't match target PGID %s. Re-creating.\n" "$USER_NAME" "$CURRENT_GID" "$PGID"
+        delgroup "$USER_NAME"
+        addgroup -g "$PGID" "$USER_NAME"
     else
-        cd "$config_target_base"
-        printf ">>> Pulling config\n"
-        git remote update
-        if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
-            git pull
-            return
-        fi
-        cd -
+        printf "Group '%s' already has the target GID %s, skipping creation.\n" "$USER_NAME" "$PGID"
     fi
-    return 1
-}
-
-start_imapfilter() {
-    # enter a subshell to not affect the pwd of the running process
-    (
-        if ! [ -d "$config_target_base" ]; then
-            echo "The directory '$config_target_base' does not exist, exiting"
-            echo "Please validate IMAPFILTER_CONFIG_BASE"
-            exit 1
-        fi
-
-        # Enter the basedir of the config. Required to allow relative
-        # includes in the lua scripts.
-        cd "$config_target_base"
-
-        log_parameter=
-        if [ -n "$IMAPFILTER_LOGFILE" ]; then
-                log_parameter="-l $IMAPFILTER_LOGFILE"
-        fi
-
-        if ! [ -f "$config_target" ]; then
-            echo "The file '$config_target' does not exist relative to '$config_target_base', exiting"
-            echo "Please validate IMAPFILTER_CONFIG"
-            exit 1
-        fi
-
-        imapfilter -c "$config_target" $log_parameter
-    )
-}
-
-imapfilter_pid=
-imapfilter_restart_daemon() {
-    if [ -n "$imapfilter_pid" ]; then
-        kill -TERM "$imapfilter_pid"
-        wait "$imapfilter_pid"
-    fi
-    start_imapfilter &
-    imapfilter_pid="$(jobs -p)"
-}
-
-loop_no_daemon() {
-    while true; do
-        pull_config
-
-        printf ">>> Running imapfilter\n"
-        if ! start_imapfilter; then
-            printf ">>> imapfilter failed\n"
-            exit 1
-        fi
-
-        printf ">>> Sleeping\n"
-        sleep "${IMAPFILTER_SLEEP:-30}"
-    done
-}
-
-loop_daemon() {
-    imapfilter_restart_daemon
-    while true; do
-        if pull_config; then
-            printf ">>> Update in VCS, restarting imapfilter daemon\n"
-            imapfilter_restart_daemon
-        fi
-
-        printf ">>> Sleeping\n"
-        sleep "${IMAPFILTER_SLEEP:-30}"
-
-        if ! kill -0 "$imapfilter_pid" 2>/dev/null; then
-            printf ">>> imapfilter daemon died, exiting\n"
-            exit 1
-        fi
-    done
-}
-
-pull_config
-if [ "$IMAPFILTER_DAEMON" = "yes" ]; then
-    loop_daemon
 else
-    loop_no_daemon
+    # Group doesn't exist, so create it
+    printf "Creating group '%s' with GID %s.\n" "$USER_NAME" "$PGID"
+    addgroup -g "$PGID" "$USER_NAME"
 fi
+
+# --- 3. Create/Recreate User based on PUID and the (now-corrected) Group ---
+# Check if the user exists
+if getent passwd "$USER_NAME" >/dev/null; then
+    # User exists, now check its ID and its primary GID
+    CURRENT_UID=$(getent passwd "$USER_NAME" | cut -d: -f3)
+    CURRENT_USER_GID=$(getent passwd "$USER_NAME" | cut -d: -f4) # New: Get the user's primary GID
+
+    if [ "$CURRENT_UID" != "$PUID" ] || [ "$CURRENT_USER_GID" != "$PGID" ]; then
+        # User exists but either the UID or the primary GID is wrong, so we delete and re-create it
+        printf "User '%s' needs update (UID/GID: %s/%s vs target %s/%s). Re-creating.\n" "$USER_NAME" "$CURRENT_UID" "$CURRENT_USER_GID" "$PUID" "$PGID"
+        deluser "$USER_NAME"
+        adduser -D -u "$PUID" -G "$USER_NAME" "$USER_NAME" # Re-create with the guaranteed-correct group name
+    else
+        printf "User '%s' already has the target UID %s and GID %s, skipping creation.\n" "$USER_NAME" "$PUID" "$PGID"
+    fi
+else
+    # User doesn't exist, so create it
+    printf "Creating user '%s' with UID %s and GID %s.\n" "$USER_NAME" "$PUID" "$PGID"
+    adduser -D -u "$PUID" -G "$USER_NAME" "$USER_NAME"
+fi
+
+# --- 4. Fix Permissions ---
+# Change ownership of key directories to the new user/group
+printf "Changing ownership of /opt/imapfilter/config and /home/%s\n" "$USER_NAME"
+# Use the numeric IDs to ensure correctness even if a name conflict occurred
+chown -R "$PUID":"$PGID" /opt/imapfilter/config /home/"$USER_NAME"
+
+# --- 5. Execute Original Application Runner ---
+# Switch to the new non-root user and execute the application runner script.
+printf "Switching user to '%s' and executing /run-imapfilter.sh\n" "$USER_NAME"
+exec su "$USER_NAME" -c /run-imapfilter.sh "$@"

--- a/run-imapfilter.sh
+++ b/run-imapfilter.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env sh
+
+vcs_token() {
+    if [ -n "$GIT_TOKEN_RAW" ]; then
+        echo "$GIT_TOKEN_RAW"
+        return
+    fi
+
+    if [ -n "$GIT_TOKEN" ]; then
+        cat "${GIT_TOKEN}"
+    fi
+
+    return 1
+}
+
+vcs_uri() {
+    s="https://"
+    if [ -n "$GIT_USER" ]; then
+        # https://user:
+        s="${s}${GIT_USER}:"
+    fi
+
+    # https://user:token@"
+    token="$(vcs_token)"
+    if [ -n "$token" ]; then
+        s="${s}${token}@"
+    fi
+
+    # https://user:token@target
+    echo "${s}${GIT_TARGET}"
+}
+
+config_in_vcs() {
+    [ -n "$(vcs_token)" ] && [ -n "$GIT_TARGET" ]
+}
+
+config_target_base="${IMAPFILTER_CONFIG_BASE:-/opt/imapfilter/config}"
+config_target="${IMAPFILTER_CONFIG}"
+
+# If config_target is an absolute path strip the base.
+# Originally IMAPFILTER_CONFIG was allowed to be absolute and relative,
+# this handles the former absolute path (as long as
+# IMAPFILTER_CONFIG_BASE is correctly used).
+case "$config_target" in
+    (/*) config_target="${config_target#${config_target_base}/}";;
+esac
+
+pull_config() {
+    config_in_vcs || return
+
+    printf ">>> Updating config\n"
+    if [ ! -d "$config_target_base" ]; then
+        printf ">>> Config has not been cloned yet, cloning\n"
+        mkdir -p "$config_target_base"
+        git clone "$(vcs_uri)" "$config_target_base"
+        return
+    else
+        cd "$config_target_base"
+        printf ">>> Pulling config\n"
+        git remote update
+        if [ "$(git rev-parse HEAD)" != "$(git rev-parse FETCH_HEAD)" ]; then
+            git pull
+            return
+        fi
+        cd -
+    fi
+    return 1
+}
+
+start_imapfilter() {
+    # enter a subshell to not affect the pwd of the running process
+    (
+        if ! [ -d "$config_target_base" ]; then
+            echo "The directory '$config_target_base' does not exist, exiting"
+            echo "Please validate IMAPFILTER_CONFIG_BASE"
+            exit 1
+        fi
+
+        # Enter the basedir of the config. Required to allow relative
+        # includes in the lua scripts.
+        cd "$config_target_base"
+
+        log_parameter=
+        if [ -n "$IMAPFILTER_LOGFILE" ]; then
+                log_parameter="-l $IMAPFILTER_LOGFILE"
+        fi
+
+        if ! [ -f "$config_target" ]; then
+            echo "The file '$config_target' does not exist relative to '$config_target_base', exiting"
+            echo "Please validate IMAPFILTER_CONFIG"
+            exit 1
+        fi
+
+        imapfilter -c "$config_target" $log_parameter
+    )
+}
+
+imapfilter_pid=
+imapfilter_restart_daemon() {
+    if [ -n "$imapfilter_pid" ]; then
+        kill -TERM "$imapfilter_pid"
+        wait "$imapfilter_pid"
+    fi
+    start_imapfilter &
+    imapfilter_pid="$(jobs -p)"
+}
+
+loop_no_daemon() {
+    while true; do
+        pull_config
+
+        printf ">>> Running imapfilter\n"
+        if ! start_imapfilter; then
+            printf ">>> imapfilter failed\n"
+            exit 1
+        fi
+
+        printf ">>> Sleeping\n"
+        sleep "${IMAPFILTER_SLEEP:-30}"
+    done
+}
+
+loop_daemon() {
+    imapfilter_restart_daemon
+    while true; do
+        if pull_config; then
+            printf ">>> Update in VCS, restarting imapfilter daemon\n"
+            imapfilter_restart_daemon
+        fi
+
+        printf ">>> Sleeping\n"
+        sleep "${IMAPFILTER_SLEEP:-30}"
+
+        if ! kill -0 "$imapfilter_pid" 2>/dev/null; then
+            printf ">>> imapfilter daemon died, exiting\n"
+            exit 1
+        fi
+    done
+}
+
+pull_config
+if [ "$IMAPFILTER_DAEMON" = "yes" ]; then
+    loop_daemon
+else
+    loop_no_daemon
+fi


### PR DESCRIPTION
## Feature: Dynamic PUID/PGID & Robust VCS Stability

This PR introduces essential functionality for managing user privileges and significantly enhances the reliability of fetching configuration via Git, addressing common failure points related to secrets and shell execution.

### 1. Security & Dynamic PUID/PGID Support

The container now runs the application as a non-root user that dynamically matches the host's User ID (PUID) and Group ID (PGID). **These environment variables are optional and will default to 1001 if not provided.** This enhances security and ensures correct file ownership.

| File | Change Summary | Benefit | 
 | ----- | ----- | ----- | 
| `entrypoint.sh` (New) | Implements PUID/PGID checks, group/user re-creation, and uses **`exec su`** to safely drop privileges before running the application. | Ensures correct file ownership and removes the container's need to run as `root` after setup. | 
| `Dockerfile` | **User creation was removed from the image build and moved to entrypoint.sh;** added the **`shadow`** package. | Enables dynamic user creation at runtime, providing the necessary tools for privilege management. | 

### 2. Robust VCS Integration

The core application script, now named `run-imapfilter.sh` (renamed from the original entrypoint), continues to execute as a low-privilege user and was hardened to make Git authentication with Personal Access Tokens (PATs) more reliable.

| Function | Change Summary | Benefit | 
 | ----- | ----- | ----- | 
| `vcs_token()` | Added **`tr -d '[:space:]'`** to token retrieval. | **Fixes Authentication:** Removes all whitespace (including newlines) from the Docker Secret, preventing token invalidation. |
| `vcs_uri()` | Implemented **protocol stripping** using a `case` statement (`${GIT_TARGET#*://}`). | **Prevents Malformed URI:** Ensures the script never creates an invalid double-prefixed URL (e.g., `https://...https://`). | 
| `pull_config()` | Refactored flow to use single `git pull --ff-only` command with `git -C <path>` and added the `--verbose` flag. | **Improved Diagnostics, Safety, & Efficiency:** Eliminates risky shell context changes (`cd`/`cd -`) and **simplifies complex update logic into a single, reliable step while making error output visible in the logs for quick troubleshooting.** | 
| Diagnostics | Added verbose Git output (`--verbose` and `2>&1`). | Ensures all detailed Git diagnostics are captured in logs for easier troubleshooting of authentication failures. | 